### PR TITLE
Updating to support node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-bowerful",
   "description": "Specify bower packages directly in grunt file.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/gyllstromk/grunt-bowerful",
   "author": {
     "name": "Karl Gyllstrom",
@@ -31,10 +31,11 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~0.7.1"
+    "bower": "~0.8.5"
   },
   "devDependencies": {
-    "grunt": "~0.3.17"
+    "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.6"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Arguments to path.join must be strings

the task fail when under node 0.10.*

Updating bower and grunt fix it
