### PR TITLE
Config dest possible split files differnt paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ grunt.initConfig({
         dest: 'public',
 
         /**
+            destfile (optional) -> filename that will be used when files are merged. Merged
+            files will default to 'assets' 
+        */
+
+        destfile: 'assets',
+
+        /**
+            customtarget (optional) -> file targets can be manually specified. 
+            key/value pairs. 
+        */
+
+        customtarget: {
+            jquery: 'web/js/vendor/jquery.js'
+        },
+
+        /**
             @packages (required) -> object of `package name: package version`
             key/value pairs. Version can be left blank.
         */

--- a/tasks/bowerful.js
+++ b/tasks/bowerful.js
@@ -32,6 +32,7 @@ module.exports = function(grunt) {
         config.directory = grunt.config.get('bowerful.store') || 'components';
         config.dest = grunt.config.get('bowerful.dest');
         config.destfile = grunt.config.get('bowerful.destfile') || 'assets';
+        config.customtarget = grunt.config.get('bowerful.customtarget');
 
         function buildConfig(packageName) {
             if (deps[packageName]) {
@@ -100,7 +101,13 @@ module.exports = function(grunt) {
                         if (! fs.existsSync(file)) {
                             grunt.log.error(file + ' not found. Skipping.');
                         } else {
-                            contents[ext] += grunt.file.read(file);
+                            // if we havent specified a custom target default to same file
+                            if(! config.customtarget[pkg.name] ) {
+                                contents[ext] += grunt.file.read(file);
+                            } else {
+                                // write in an individual file
+                                grunt.file.write(path.join(config.customtarget[pkg.name]), grunt.file.read(file));
+                            }
                         }
                     });
 

--- a/tasks/bowerful.js
+++ b/tasks/bowerful.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
         config.directory = grunt.config.get('bowerful.store') || 'components';
         config.dest = grunt.config.get('bowerful.dest');
         config.destfile = grunt.config.get('bowerful.destfile') || 'assets';
-        config.customtarget = grunt.config.get('bowerful.customtarget');
+        config.customtarget = grunt.config.get('bowerful.customtarget') || {};
 
         function buildConfig(packageName) {
             if (deps[packageName]) {

--- a/tasks/bowerful.js
+++ b/tasks/bowerful.js
@@ -31,6 +31,7 @@ module.exports = function(grunt) {
         var packages = grunt.config.get('bowerful.packages');
         config.directory = grunt.config.get('bowerful.store') || 'components';
         config.dest = grunt.config.get('bowerful.dest');
+        config.destfile = grunt.config.get('bowerful.destfile') || 'assets';
 
         function buildConfig(packageName) {
             if (deps[packageName]) {
@@ -109,7 +110,7 @@ module.exports = function(grunt) {
                 grunt.util._.keys(configs).forEach(write);
 
                 Object.keys(contents).forEach(function(ext) {
-                    grunt.file.write(path.join(config.dest, 'assets' + ext), contents[ext]);
+                    grunt.file.write(path.join(config.dest, config.destfile + ext), contents[ext]);
                 });
             }
 


### PR DESCRIPTION
option added to config to allow specifing custom targets

example of usage:

```
bowerful: {
    store: 'components',
    dest: 'web/js/vendor',
    destfile: 'vendor',
    customtarget: {
        jquery: 'web/js/vendor/jquery.js'
    },
    packages: {
        jquery: '', 
        underscore: '', 
        backbone: ''
    } 
}
```

this will concatinate files on vendor.js and also create a file jquery.js.

This will solve issue https://github.com/gyllstromk/grunt-bowerful/issues/5 
