### PR TITLE
Bump bower to 1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~0.9.2"
+    "bower": "~1.2.5"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Should probably bump the core version to 0.4 to keep up with semantic versioning.
